### PR TITLE
Database seed refactors

### DIFF
--- a/app/Models/Box/Type.php
+++ b/app/Models/Box/Type.php
@@ -3,6 +3,7 @@
 namespace App\Models\Box;
 
 use Illuminate\Database\Eloquent\Model;
+use Webpatser\Uuid\Uuid;
 
 class Type extends Model
 {

--- a/app/Models/Box/Type.php
+++ b/app/Models/Box/Type.php
@@ -14,6 +14,14 @@ class Type extends Model
      */
     public $incrementing = false;
 
+    protected $fillable = [
+        'title',
+        'slug',
+        'icon',
+        'format',
+        'partial'
+    ];
+
     protected static function boot()
     {
         parent::boot();

--- a/config/database.php
+++ b/config/database.php
@@ -72,7 +72,7 @@ return [
             'password' => env('DB_PASSWORD', ''),
             'charset'  => 'utf8',
             'prefix'   => '',
-            'schema'   => 'public',
+            'schema'   => env('DB_SCHEMA', 'public'),
         ],
 
         'sqlsrv' => [

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -14,7 +14,7 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
+            $table->string('name')->nullable();
             $table->string('email')->unique();
             $table->string('password', 60);
             $table->rememberToken();

--- a/database/seeds/PositionSeeder.php
+++ b/database/seeds/PositionSeeder.php
@@ -2,6 +2,7 @@
 
 namespace App\Seeds;
 
+use App\Models\Box\Position;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Webpatser\Uuid\Uuid;
@@ -15,20 +16,23 @@ class PositionSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('positions')->insert([
-            'id' => Uuid::generate(4),
-            'name' => 'left',
-        ]);
+        // Add transaction to secure against faulty errors
+        DB::beginTransaction();
 
-        DB::table('positions')->insert([
-            'id' => Uuid::generate(4),
-            'name' => 'center',
-        ]);
+        // Reset table
+        DB::table('positions')->truncate();
 
-        DB::table('positions')->insert([
-            'id' => Uuid::generate(4),
-            'name' => 'right',
-        ]);
+        $names = ['left', 'center', 'right'];
+        // We use models to avoid null constraint violations
+        // in the timestamp columns
+        foreach($names as $name) {
+            $position = new Position;
+            $position->id = Uuid::generate(4);
+            $position->name = $name;
+            $position->save();
+        }
+
+        DB::commit();
 
         $this->command->info('Box positions seeded');
     }

--- a/database/seeds/TypeSeeder.php
+++ b/database/seeds/TypeSeeder.php
@@ -2,6 +2,7 @@
 
 namespace App\Seeds;
 
+use App\Models\Box\Type;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Facades\DB;
 use Webpatser\Uuid\Uuid;
@@ -15,23 +16,33 @@ class TypeSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('types')->insert([
-            'id' => Uuid::generate(4),
+        // Begin transaction to protect against faulty inserts
+        DB::beginTransaction();
+
+        // Reset table
+        DB::table('types')->truncate();
+
+        $type = new Type;
+        $type->fill([
             'title' => 'GitHub commits',
             'slug' => 'github-commits',
             'icon' => 'github',
             'format' => '{ "commits": { "options": { "label": "Commits:", "type": "text" } }, "repository": { "options":{ "label": "Repository:", "type": "select", "engine": "App\\\Service\\\GitHubService@getFormRepositories"}}}',
             'partial' => 'git.github.commits',
         ]);
+        $type->save();
 
-        DB::table('types')->insert([
-            'id' => Uuid::generate(4),
+        $type = new Type;
+        $type->fill([
             'title' => 'Server status',
             'slug' => 'server-status',
             'icon' => 'server',
             'format' => '{"url":{"options":{"label":"Url:","type":"text"}}}',
             'partial' => 'server.status',
         ]);
+        $type->save();
+
+        DB::commit();
 
         $this->command->info('Box types seeded');
     }


### PR DESCRIPTION
Strict database engines like Postgres was throwing not null violation errors, because you used `DB::insert` which does not automatically insert `created_at` and `updated_at` values.